### PR TITLE
Updates crypto_ipcrypt to use libc::c_char

### DIFF
--- a/src/crypto_ipcrypt.rs
+++ b/src/crypto_ipcrypt.rs
@@ -254,7 +254,7 @@ pub fn bytes_to_ipv4(bytes: &[u8; BYTES]) -> Option<[u8; 4]> {
 pub fn parse_ip(ip: &str) -> Result<[u8; BYTES], SodiumError> {
     let mut bin = [0u8; BYTES];
     let ret = unsafe {
-        libsodium_sys::sodium_ip2bin(bin.as_mut_ptr(), ip.as_ptr() as *const i8, ip.len())
+        libsodium_sys::sodium_ip2bin(bin.as_mut_ptr(), ip.as_ptr() as *const libc::c_char, ip.len())
     };
     if ret == 0 {
         Ok(bin)
@@ -285,7 +285,7 @@ pub fn parse_ip(ip: &str) -> Result<[u8; BYTES], SodiumError> {
 /// ```
 pub fn format_ip(bin: &[u8; BYTES]) -> String {
     let mut buf = [0i8; IP_MAXLEN];
-    let ptr = unsafe { libsodium_sys::sodium_bin2ip(buf.as_mut_ptr(), IP_MAXLEN, bin.as_ptr()) };
+    let ptr = unsafe { libsodium_sys::sodium_bin2ip(buf.as_mut_ptr() as *mut libc::c_char, IP_MAXLEN, bin.as_ptr()) };
     if ptr.is_null() {
         // This shouldn't happen for valid 16-byte input, but handle it anyway
         String::new()


### PR DESCRIPTION
Compile errors found on aarch64-unknown-linux-gnu with the rustc below.  Two locations needed to be updated to use libc::c_char.

```shell
$ rustc -vV
rustc 1.92.0 (ded5c06cf 2025-12-08)
binary: rustc
commit-hash: ded5c06cf21d2b93bffd5d884aa6e96934ee4234 commit-date: 2025-12-08
host: aarch64-unknown-linux-gnu
release: 1.92.0
LLVM version: 21.1.3
```

I haven't added doc or explicit tests to keep the changes as minimal as possible.