### PR TITLE
error: Add derive for Clone, PartialEq and Eq

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 use thiserror::Error;
 
 /// Error type for libsodium operations
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum SodiumError {
     /// Hex decoding failed
     #[error("Invalid hexadecimal string")]


### PR DESCRIPTION
Make it possible to duplicate the `SodiumError` type and to compare it with itself.